### PR TITLE
export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(GHEX_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${GHEX_MODULE_PATH}")
 
 find_package(MPI REQUIRED)
+find_package(Boost 1.66 REQUIRED)
 find_package(GridTools REQUIRED HINTS ${GridTools_DIR})
 # NOT USED:
 # find_package(PMIx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,86 +1,94 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+project(GHEX VERSION 0.1 LANGUAGES CXX)
+if(USE_GPU)
+  enable_language(CUDA)
+endif()
+
 cmake_policy(SET CMP0048 NEW)
+enable_testing()
 
 set(USE_GPU "OFF" CACHE BOOL "use cuda")
 set(USE_MPI_WITH_UCX_IN_TESTS "OFF" CACHE BOOL "use ucx for unit test")
 set(USE_HYBRID_TESTS "ON" CACHE BOOL "run gpu+cpu tests")
 
-if(USE_GPU)
-    project(GHEX VERSION 0.1 LANGUAGES CXX CUDA)
-else()
-    project(GHEX VERSION 0.1 LANGUAGES CXX)
-endif()
-
-
 set(CMAKE_CXX_STANDARD 14)
-
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic") # Last option is because of a problem with GCC9. Try to remove with more releases of the compiler
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug)
+  set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-set(GHEX_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(GHEX_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${GHEX_MODULE_PATH}")
-message(">>>>>>>>>>>>>>>>${CMAKE_MODULE_PATH}")
 
 find_package(MPI REQUIRED)
 find_package(GridTools REQUIRED HINTS ${GridTools_DIR})
-find_package(Boost)
-find_package(PMIx)
-find_package(UCP)
+# NOT USED:
+# find_package(PMIx)
+# find_package(UCP)
 
-message(">>>>>>>>>>>>>>>>${GridTools_MODULE_PATH}")
 list(APPEND CMAKE_MODULE_PATH "${GridTools_MODULE_PATH}")
 
-add_library(GHEX_libs INTERFACE)
-target_include_directories(GHEX_libs INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    )
-target_link_libraries(GHEX_libs INTERFACE GridTools::gridtools)
+add_library(ghexlib INTERFACE)
+add_library(GHEX::ghexlib ALIAS ghexlib)
+target_include_directories(ghexlib INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+target_link_libraries(ghexlib INTERFACE GridTools::gridtools)
+target_compile_features(ghexlib INTERFACE cxx_std_14)
 
-enable_testing()
-
-set(GHEX_GTEST_DIR ${GridTools_DIR}/_deps/googletest-src CACHE FILEPATH "Place where to find googletest installation")
-
-find_path(GTEST_INC_DIR
-    "gtest/gtest.h"
-    HINTS
-    ${GHEX_GTEST_DIR}/include
-    ${GHEX_GTEST_DIR}/googletest/include)
-if(NOT GTEST_INC_DIR)
-    message(FATAL_ERROR "Couldn't find gtest/gtest.h under folder GHEX_GTEST_DIR = " ${GHEX_GTEST_DIR})
-endif()
-
-find_path(GTEST_SOURCE_DIR
-    gtest-all.cc
-    HINTS
-    ${GHEX_GTEST_DIR}/src
-    ${GHEX_GTEST_DIR}/googletest/src
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.10.0
 )
-if(NOT GTEST_SOURCE_DIR)
-    message(FATAL_ERROR "Couldn't find gtest-all.cc under folder GHEX_TEST_DIR = " ${GHEX_GTEST_DIR})
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+  FetchContent_Populate(googletest)
+  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+  # https://github.com/google/googletest/issues/2429
+  add_library(GTest::gtest ALIAS gtest)
 endif()
 
-set(GTEST_LIB_SOURCES ${GTEST_SOURCE_DIR}/gtest-all.cc)
-set(GTEST_INCLUDE_DIRS ${GTEST_INC_DIR} ${GTEST_SOURCE_DIR} ${GTEST_SOURCE_DIR}/..)
+add_library(gtest_main_mt utils/gtest_main.cpp)
+target_link_libraries(gtest_main_mt MPI::MPI_CXX GridTools::gridtools GTest::gtest)
 
-add_library(gtest_main_mt ${GTEST_LIB_SOURCES} ${GTEST_MAIN_SOURCES} ./utils/gtest_main.cpp )
-target_include_directories(gtest_main_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-target_link_libraries(gtest_main_mt MPI::MPI_CXX GridTools::gridtools )
+add_library(gtest_main_bench utils/gtest_main_bench.cpp )
+target_link_libraries(gtest_main_bench MPI::MPI_CXX GridTools::gridtools GTest::gtest)
 
-add_library(gtest_main_bench ${GTEST_LIB_SOURCES} ${GTEST_MAIN_SOURCES} ./utils/gtest_main_bench.cpp )
-target_link_libraries(gtest_main_bench MPI::MPI_CXX GridTools::gridtools )
-target_include_directories(gtest_main_bench PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-
-add_library(gtest_main_bench_mt ${GTEST_LIB_SOURCES} ${GTEST_MAIN_SOURCES} ./utils/gtest_main_bench.cpp )
-target_link_libraries(gtest_main_bench_mt MPI::MPI_CXX GridTools::gridtools )
-target_include_directories(gtest_main_bench_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
+add_library(gtest_main_bench_mt ./utils/gtest_main_bench.cpp)
+target_link_libraries(gtest_main_bench_mt MPI::MPI_CXX GridTools::gridtools GTest::gtest)
 target_compile_definitions(gtest_main_bench_mt PRIVATE GHEX_BENCHMARKS_USE_MULTI_THREADED_MPI)
 
 add_subdirectory(tests)
 add_subdirectory(benchmarks)
+
+include(GNUInstallDirs)
+install(TARGETS ghexlib EXPORT GHEX-targets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(EXPORT GHEX-targets
+  FILE GHEX-targets.cmake
+  NAMESPACE GHEX::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  )
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  cmake/GHEXConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/GHEXConfig.cmake
+  INSTALL_DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake)
+write_basic_package_version_file(GHEXConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+  )
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/GHEXConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/GHEXConfigVersion.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(ghexlib INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   )
-target_link_libraries(ghexlib INTERFACE GridTools::gridtools)
+target_link_libraries(ghexlib INTERFACE GridTools::gridtools MPI::MPI_CXX)
 target_compile_features(ghexlib INTERFACE cxx_std_14)
 
 include(FetchContent)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # simple benchmarks
 # -----------------
 
@@ -6,17 +5,14 @@
 set(_benchmarks_simple simple_comm_test_halo_exchange_3D_generic_full)
 # Variable used for benchmarks that require multithreading support
 set(_benchmarks_simple_mt )
-
 foreach (_t ${_benchmarks_simple})
-    add_executable(${_t} ${_t}.cpp )
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_bench)
+  add_executable(${_t} ${_t}.cpp )
+  target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_bench ghexlib)
 endforeach()
 
 foreach (_t ${_benchmarks_simple_mt})
-    add_executable(${_t}_mt ${_t}.cpp )
-    target_include_directories(${_t}_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t}_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt)
+  add_executable(${_t}_mt ${_t}.cpp )
+  target_link_libraries(${_t}_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt ghexlib)
 endforeach()
 
 
@@ -29,46 +25,38 @@ set(_benchmarks gcl_test_halo_exchange_3D_generic_full comm_2_test_halo_exchange
 set(_benchmarks_mt )
 
 foreach (_t ${_benchmarks})
-    add_executable(${_t} ${_t}.cpp)
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_bench)
+  add_executable(${_t} ${_t}.cpp)
+  target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_bench ghexlib)
 
-    add_executable(${_t}_1_pattern ${_t}.cpp)
-    target_include_directories(${_t}_1_pattern PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_compile_definitions(${_t}_1_pattern PUBLIC GHEX_1_PATTERN_BENCHMARK) 
-    target_link_libraries(${_t}_1_pattern MPI::MPI_CXX GridTools::gridtools gtest_main_bench)
+  add_executable(${_t}_1_pattern ${_t}.cpp)
+  target_compile_definitions(${_t}_1_pattern PUBLIC GHEX_1_PATTERN_BENCHMARK)
+  target_link_libraries(${_t}_1_pattern MPI::MPI_CXX GridTools::gridtools gtest_main_bench ghexlib)
 
-    if(USE_GPU)
-        add_executable(${_t}_gpu ${_t}.cu)
-        target_include_directories(${_t}_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(${_t}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_bench)
+  if(USE_GPU)
+    add_executable(${_t}_gpu ${_t}.cu)
+    target_link_libraries(${_t}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_bench ghexlib)
 
-        add_executable(${_t}_1_pattern_gpu ${_t}.cu)
-        target_include_directories(${_t}_1_pattern_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_compile_definitions(${_t}_1_pattern_gpu PUBLIC GHEX_1_PATTERN_BENCHMARK) 
-        target_link_libraries(${_t}_1_pattern_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_bench)
-    endif()
+    add_executable(${_t}_1_pattern_gpu ${_t}.cu)
+    target_compile_definitions(${_t}_1_pattern_gpu PUBLIC GHEX_1_PATTERN_BENCHMARK)
+    target_link_libraries(${_t}_1_pattern_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_bench ghexlib)
+  endif()
 endforeach()
 
 foreach (_t ${_benchmarks_mt})
-    add_executable(${_t}_mt ${_t}.cpp)
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t}_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt)
+  add_executable(${_t}_mt ${_t}.cpp)
+  target_link_libraries(${_t}_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt ghexlib)
 
-    add_executable(${_t}_1_pattern_mt ${_t}.cpp)
-    target_include_directories(${_t}_1_pattern_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_compile_definitions(${_t}_1_pattern_mt PUBLIC GHEX_1_PATTERN_BENCHMARK) 
-    target_link_libraries(${_t}_1_pattern_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt)
+  add_executable(${_t}_1_pattern_mt ${_t}.cpp)
+  target_compile_definitions(${_t}_1_pattern_mt PUBLIC GHEX_1_PATTERN_BENCHMARK)
+  target_link_libraries(${_t}_1_pattern_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt ghexlib)
 
-    if(USE_GPU)
-        add_executable(${_t}_gpu_mt ${_t}.cu)
-        target_include_directories(${_t}_gpu_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(${_t}_gpu_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt)
+  if(USE_GPU)
+    add_executable(${_t}_gpu_mt ${_t}.cu)
+    target_link_libraries(${_t}_gpu_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt ghexlib)
 
-        add_executable(${_t}_1_pattern_gpu_mt ${_t}.cu)
-        target_include_directories(${_t}_1_pattern_gpu_mt PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_compile_definitions(${_t}_1_pattern_gpu_mt PUBLIC GHEX_1_PATTERN_BENCHMARK) 
-        target_link_libraries(${_t}_1_pattern_gpu_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt)
-    endif()
+    add_executable(${_t}_1_pattern_gpu_mt ${_t}.cu)
+    target_compile_definitions(${_t}_1_pattern_gpu_mt PUBLIC GHEX_1_PATTERN_BENCHMARK)
+    target_link_libraries(${_t}_1_pattern_gpu_mt MPI::MPI_CXX GridTools::gridtools gtest_main_bench_mt ghexlib)
+  endif()
 endforeach()
 

--- a/cmake/FindPMIx.cmake
+++ b/cmake/FindPMIx.cmake
@@ -30,3 +30,10 @@ find_package_handle_standard_args(PMIx DEFAULT_MSG PMIX_LIBRARY PMIX_INCLUDE_DIR
 
 mark_as_advanced(PMIX_ROOT PMIX_LIBRARY PMIX_INCLUDE_DIR)
 
+if(NOT TARGET PMIx::libpmix AND PMIx_FOUND)
+  add_library(PMIx::libpmix SHARED IMPORTED)
+  set_target_properties(PMIx::libpmix PROPERTIES
+    IMPORTED_LOCATION ${PMIX_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${PMIX_INCLUDE_DIR}
+  )
+endif()

--- a/cmake/FindUCP.cmake
+++ b/cmake/FindUCP.cmake
@@ -19,3 +19,11 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(UCP DEFAULT_MSG UCP_LIBRARY UCP_INCLUDE_DIR)
 
 mark_as_advanced(UCX_ROOT UCP_LIBRARY UCP_INCLUDE_DIR)
+
+if(NOT TARGET UCP::libucp AND UCP_FOUND)
+  add_library(UCP::libucp SHARED IMPORTED)
+  set_target_properties(UCP::libucp PROPERTIES
+    IMPORTED_LOCATION ${UCP_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${UCP_INCLUDE_DIR}
+  )
+endif()

--- a/cmake/GHEXConfig.cmake.in
+++ b/cmake/GHEXConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+find_dependency(GridTools @GridTools_VERSION@)
+include(${CMAKE_CURRENT_LIST_DIR}/GHEX-targets.cmake)

--- a/cmake/GHEXConfig.cmake.in
+++ b/cmake/GHEXConfig.cmake.in
@@ -1,4 +1,5 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
+find_dependency(MPI)
 find_dependency(GridTools @GridTools_VERSION@)
 include(${CMAKE_CURRENT_LIST_DIR}/GHEX-targets.cmake)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,124 +1,108 @@
-
 if(USE_MPI_WITH_UCX_IN_TESTS)
-    set(_ucx_params -mca pml ucx)
+  set(_ucx_params -mca pml ucx)
 else()
-    set(_ucx_params )
+  set(_ucx_params )
 endif()
 
 set(_serial_tests aligned_allocator)
-
 foreach (_t ${_serial_tests})
-    add_executable(${_t} ${_t}.cpp)
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-    add_test(
-        NAME ${_t}.cpp
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
-    )
+  add_executable(${_t} ${_t}.cpp)
+  target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+  add_test(
+    NAME ${_t}.cpp
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
+  )
 endforeach()
 
 set(_tests mpi_allgather communication_object)
-
 foreach (_t ${_tests})
-    add_executable(${_t} ${_t}.cpp)
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-    add_test(
-        NAME ${_t}.cpp
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
-    )
+  add_executable(${_t} ${_t}.cpp)
+  target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+  add_test(
+    NAME ${_t}.cpp
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
+  )
 endforeach()
 
 set(_variants serial serial_split threads async_async async_deferred async_async_wait)
-
 foreach(_var ${_variants})
-    string(TOUPPER ${_var} define)
-    add_executable(communication_object_2_${_var} communication_object_2.cpp )
-    target_compile_definitions(communication_object_2_${_var} PUBLIC GHEX_TEST_${define})
-    target_include_directories(communication_object_2_${_var} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(communication_object_2_${_var} MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
+  string(TOUPPER ${_var} define)
+  add_executable(communication_object_2_${_var} communication_object_2.cpp)
+  target_compile_definitions(communication_object_2_${_var} PUBLIC GHEX_TEST_${define})
+  target_link_libraries(communication_object_2_${_var} MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+  add_test(
+    NAME communication_object_2_${_var}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var} ${MPIEXEC_POSTFLAGS}
+  )
+
+  add_executable(communication_object_2_${_var}_vector communication_object_2.cpp)
+  target_compile_definitions(communication_object_2_${_var}_vector PUBLIC GHEX_TEST_${define}_VECTOR)
+  target_link_libraries(communication_object_2_${_var}_vector MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+  add_test(
+    NAME communication_object_2_${_var}_vector
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_vector ${MPIEXEC_POSTFLAGS}
+  )
+
+  if (USE_HYBRID_TESTS)
+    add_executable(communication_object_2_${_var}_hybrid communication_object_2.cpp )
+    target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_TEST_${define})
+    target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_EMULATE_GPU)
+    target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_HYBRID_TESTS)
+    target_link_libraries(communication_object_2_${_var}_hybrid MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
     add_test(
-        NAME communication_object_2_${_var}
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var} ${MPIEXEC_POSTFLAGS}
+      NAME communication_object_2_${_var}_hybrid
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_hybrid ${MPIEXEC_POSTFLAGS}
+    )
+  endif()
+  if (USE_GPU)
+    add_executable(communication_object_2_${_var}_gpu communication_object_2.cu)
+    target_compile_definitions(communication_object_2_${_var}_gpu PUBLIC GHEX_TEST_${define})
+    target_link_libraries(communication_object_2_${_var}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+    add_test(
+      NAME communication_object_2_${_var}_gpu
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_gpu ${MPIEXEC_POSTFLAGS}
     )
 
-    add_executable(communication_object_2_${_var}_vector communication_object_2.cpp )
-    target_compile_definitions(communication_object_2_${_var}_vector PUBLIC GHEX_TEST_${define}_VECTOR)
-    target_include_directories(communication_object_2_${_var}_vector PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(communication_object_2_${_var}_vector MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
+    add_executable(communication_object_2_${_var}_vector_gpu communication_object_2.cu)
+    target_compile_definitions(communication_object_2_${_var}_vector_gpu PUBLIC GHEX_TEST_${define}_VECTOR)
+    target_link_libraries(communication_object_2_${_var}_vector_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
     add_test(
-        NAME communication_object_2_${_var}_vector
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_vector ${MPIEXEC_POSTFLAGS}
+      NAME communication_object_2_${_var}_vector_gpu
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_vector_gpu ${MPIEXEC_POSTFLAGS}
     )
 
     if (USE_HYBRID_TESTS)
-        add_executable(communication_object_2_${_var}_hybrid communication_object_2.cpp )
-        target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_TEST_${define})
-        target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_EMULATE_GPU)
-        target_compile_definitions(communication_object_2_${_var}_hybrid PUBLIC GHEX_HYBRID_TESTS)
-        target_include_directories(communication_object_2_${_var}_hybrid PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(communication_object_2_${_var}_hybrid MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-        add_test(
-            NAME communication_object_2_${_var}_hybrid
-            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_hybrid ${MPIEXEC_POSTFLAGS}
-        )
+      add_executable(communication_object_2_${_var}_hybrid_gpu communication_object_2.cu)
+      target_compile_definitions(communication_object_2_${_var}_hybrid_gpu PUBLIC GHEX_TEST_${define})
+      target_compile_definitions(communication_object_2_${_var}_hybrid_gpu PUBLIC GHEX_HYBRID_TESTS)
+      target_link_libraries(communication_object_2_${_var}_hybrid_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+      add_test(
+          NAME communication_object_2_${_var}_hybrid_gpu
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_hybrid_gpu ${MPIEXEC_POSTFLAGS}
+      )
     endif()
-    if (USE_GPU)
-        add_executable(communication_object_2_${_var}_gpu communication_object_2.cu)
-        target_compile_definitions(communication_object_2_${_var}_gpu PUBLIC GHEX_TEST_${define})
-        target_include_directories(communication_object_2_${_var}_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(communication_object_2_${_var}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-        add_test(
-            NAME communication_object_2_${_var}_gpu
-            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_gpu ${MPIEXEC_POSTFLAGS}
-        )
-
-        add_executable(communication_object_2_${_var}_vector_gpu communication_object_2.cu)
-        target_compile_definitions(communication_object_2_${_var}_vector_gpu PUBLIC GHEX_TEST_${define}_VECTOR)
-        target_include_directories(communication_object_2_${_var}_vector_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(communication_object_2_${_var}_vector_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-        add_test(
-            NAME communication_object_2_${_var}_vector_gpu
-            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_vector_gpu ${MPIEXEC_POSTFLAGS}
-        )
-
-        if (USE_HYBRID_TESTS)
-            add_executable(communication_object_2_${_var}_hybrid_gpu communication_object_2.cu)
-            target_compile_definitions(communication_object_2_${_var}_hybrid_gpu PUBLIC GHEX_TEST_${define})
-            target_compile_definitions(communication_object_2_${_var}_hybrid_gpu PUBLIC GHEX_HYBRID_TESTS)
-            target_include_directories(communication_object_2_${_var}_hybrid_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-            target_link_libraries(communication_object_2_${_var}_hybrid_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-            add_test(
-                NAME communication_object_2_${_var}_hybrid_gpu
-                COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 8 ${MPIEXEC_PREFLAGS} ${_ucx_params} communication_object_2_${_var}_hybrid_gpu ${MPIEXEC_POSTFLAGS}
-            )
-        endif()
-    endif()
+  endif()
 endforeach(_var)
 
-
 set(_tests_gt data_store_test)
-
 foreach (_t ${_tests_gt})
-    add_executable(${_t} ${_t}.cpp)
-    target_include_directories(${_t} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-    add_test(
-        NAME ${_t}.cpp
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
-    )
+  add_executable(${_t} ${_t}.cpp)
+  target_link_libraries(${_t} MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+  add_test(
+    NAME ${_t}.cpp
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
+  )
 endforeach()
 if (USE_GPU)
-    foreach (_t ${_tests_gt})
-        add_executable(${_t}_gpu ${_t}.cu)
-        target_compile_definitions(${_t}_gpu PUBLIC GT_USE_GPU) 
-        target_include_directories(${_t}_gpu PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-        target_link_libraries(${_t}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt)
-        add_test(
-            NAME ${_t}.cu
-            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
-        )
-    endforeach()
+  foreach (_t ${_tests_gt})
+    add_executable(${_t}_gpu ${_t}.cu)
+    target_compile_definitions(${_t}_gpu PUBLIC GT_USE_GPU)
+    target_link_libraries(${_t}_gpu MPI::MPI_CXX GridTools::gridtools gtest_main_mt ghexlib)
+    add_test(
+      NAME ${_t}.cu
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${_ucx_params} ${_t} ${MPIEXEC_POSTFLAGS}
+    )
+  endforeach()
 endif()
 
 add_subdirectory(transport)

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -1,15 +1,10 @@
-
 set(_tests test_low_level test_low_level_x test_send_multi test_cancel_request test_attach_detach)
-
 foreach(t_ ${_tests})
-
-    add_executable( ${t_} ./${t_}.cpp )
-    target_include_directories(${t_} PRIVATE ${CMAKE_SOURCE_DIR}/include ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(${t_}  GridTools::gridtools MPI::MPI_CXX gtest_main_mt)
-    add_test(
-        NAME ${t_}.cpp
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${t_} ${MPIEXEC_POSTFLAGS}
-    )
-
+  add_executable( ${t_} ./${t_}.cpp )
+  target_link_libraries(${t_}  GridTools::gridtools MPI::MPI_CXX gtest_main_mt ghexlib)
+  add_test(
+    NAME ${t_}.cpp
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${t_} ${MPIEXEC_POSTFLAGS}
+  )
 endforeach(t_ ${_tests})
 


### PR DESCRIPTION
- GTest uses `FetchContent`
- Properly link against GTest
- Creates a `ghexlib` target and link against it
- Export targets / cmake config mode

The benchmark CMakeLists.txt would still benefit from a function that creates all these targets.