### PR TITLE
Prevent UCX lockup in tests

### DIFF
--- a/include/ghex/transport_layer/ucx/context.hpp
+++ b/include/ghex/transport_layer/ucx/context.hpp
@@ -66,12 +66,24 @@ namespace gridtools {
                     ~transport_context()
                     {
                         // ucp_worker_destroy should be called after a barrier
-                        MPI_Barrier(m_mpi_comm);
+                        // use MPI IBarrier and progress all workers
+                        MPI_Request req = MPI_REQUEST_NULL;
+                        int flag;
+                        MPI_Ibarrier(m_mpi_comm, &req);
+                        while(true)
                         {
+                            // make communicators from workers and progress
                             for (auto& w_ptr : m_workers)
-                                w_ptr->m_endpoint_cache.clear();
-                            m_worker->m_endpoint_cache.clear();
+                                communicator_type{m_worker.get(), w_ptr.get()}.progress();
+                            communicator_type{m_worker.get(), m_worker.get()}.progress();
+                            MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+                            if(flag) break;
                         }
+                        // close endpoints
+                        for (auto& w_ptr : m_workers)
+                            w_ptr->m_endpoint_cache.clear();
+                        m_worker->m_endpoint_cache.clear();
+                        // another MPI barrier to be sure
                         MPI_Barrier(m_mpi_comm);
                     }
 


### PR DESCRIPTION
- test_ucx_context (multi-threaded) locked up from time to time, reason remains unclear
- lockup happens during endpoint destruction (end of program)
- data seem to be sent and received correctly
- suspicion: some ucx internals were not fully completed since threads are joined once data array is (locally) reusable
- progressing all workers during context destruction removes the issue (as far as we know)
- reason why exactly this works is not clear