### PR TITLE
remap MPI ranks to PMIx ranks in the PMIx address db

### DIFF
--- a/include/ghex/transport_layer/ucx/address_db_pmi.hpp
+++ b/include/ghex/transport_layer/ucx/address_db_pmi.hpp
@@ -72,7 +72,7 @@ namespace gridtools {
                         // map MPI communicator ranks to PMIx ranks
                         m_rank_map.resize(mpi_size);
                         for(int i=0; i<mpi_size; i++) m_rank_map[i] = m_rank;
-                        GHEX_CHECK_MPI_RESULT(MPI_Alltoall(MPI_IN_PLACE, 0, MPI_INT, m_rank_map.data(), sizeof(key_t), MPI_BYTE, comm));
+                        GHEX_CHECK_MPI_RESULT(MPI_Alltoall(MPI_IN_PLACE, 0, MPI_BYTE, m_rank_map.data(), sizeof(key_t), MPI_BYTE, comm));
                         
                         // from now on use the MPI communicator rank outsize, and remap for internal use
                         m_rank = mpi_rank;

--- a/include/ghex/transport_layer/ucx/address_db_pmi.hpp
+++ b/include/ghex/transport_layer/ucx/address_db_pmi.hpp
@@ -72,7 +72,7 @@ namespace gridtools {
                         // map MPI communicator ranks to PMIx ranks
                         m_rank_map.resize(mpi_size);
                         for(int i=0; i<mpi_size; i++) m_rank_map[i] = m_rank;
-                        GHEX_CHECK_MPI_RESULT(MPI_Alltoall(MPI_IN_PLACE, 0, MPI_INT, m_rank_map.data(), 1, MPI_INT, comm));
+                        GHEX_CHECK_MPI_RESULT(MPI_Alltoall(MPI_IN_PLACE, 0, MPI_INT, m_rank_map.data(), sizeof(key_t), MPI_BYTE, comm));
                         
                         // from now on use the MPI communicator rank outsize, and remap for internal use
                         m_rank = mpi_rank;

--- a/include/ghex/transport_layer/ucx/address_db_pmi.hpp
+++ b/include/ghex/transport_layer/ucx/address_db_pmi.hpp
@@ -72,7 +72,7 @@ namespace gridtools {
                         // map MPI communicator ranks to PMIx ranks
                         m_rank_map.resize(mpi_size);
                         for(int i=0; i<mpi_size; i++) m_rank_map[i] = m_rank;
-                        MPI_Alltoall(MPI_IN_PLACE, 0, MPI_INT, m_rank_map.data(), 1, MPI_INT, comm);
+                        GHEX_CHECK_MPI_RESULT(MPI_Alltoall(MPI_IN_PLACE, 0, MPI_INT, m_rank_map.data(), 1, MPI_INT, comm));
                         
                         // from now on use the MPI communicator rank outsize, and remap for internal use
                         m_rank = mpi_rank;


### PR DESCRIPTION
This is necessary in cases when ghex is initialized with a communicator with remapped ranks (e.g., hwcart). In that case PMIx has the same numbering as MPI_COMM_WORLD, but GHEX is using different rank numbers that come from the renumbered communicator. To use PMIx those need to be remapped.